### PR TITLE
Add floating save button

### DIFF
--- a/app/assets/stylesheets/pages/_note.sass
+++ b/app/assets/stylesheets/pages/_note.sass
@@ -1,2 +1,20 @@
 .nav-wrapper a
   color: black !important
+
+.action
+  position: fixed
+  right: 1rem
+  bottom: 1rem
+
+.action__inner i
+  font-size: 16px
+
+  margin-top: 9px
+  margin-bottom: 9px
+  margin-right: 4px
+
+.action__inner p
+  margin: 0px
+
+tbody .row
+  height: 3rem

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -14,8 +14,9 @@
     #js-note_all-search-result-tweets.hidden
       = @note.all_search_result_tweets
 
-  .actions
+  .action
     = button_tag type: "submit", class: "waves-effect waves-light btn" do
-      i.material-icons
-        | done
-      | 保存
+      .action__inner
+        i.material-icons
+          | done
+        | 保存

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -37,12 +37,9 @@
               | 削除
             |  
 
-footer
-  .container
-    .row
-      ul#nav-mobile.right.hide-on-med-and-down
-        li
-          = link_to new_note_path, class: "waves-effect waves-light btn" do
-            i.material-icons
-              | add
-            | 追加
+.action
+  = link_to new_note_path, class: "waves-effect waves-light btn" do
+    .action__inner
+      i.material-icons
+        | add
+      | 追加

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -2,14 +2,16 @@
   .col.s12
     h1
       = @note.title
-
-    = link_to edit_note_path(@note), class: "waves-effect waves-light btn grey"
-      i.material-icons
-        | edit
-      | 編集
-
+  
   .container  
     h3
       = Note.human_attribute_name(:body)
     pre.grey.lighten-2
       = @note.body
+
+.action
+  = link_to edit_note_path(@note), class: "waves-effect waves-light btn grey"
+    .action__inner
+      i.material-icons
+        | edit
+      | 編集


### PR DESCRIPTION
#104 

## 参考
[マテリアルデザインでの「ボタン」の使用ルールと作り方（サンプルCSS付）](https://saruwakakun.com/html-css/material/button)

## 問題
- 追加してみたものの、なんか違う気がする

<img width="256" alt="スクリーンショット 2020-01-09 17 59 59" src="https://user-images.githubusercontent.com/42843963/72053218-eb158600-3309-11ea-987d-b6716988cbd1.png">

### 追加前
<img width="1403" alt="スクリーンショット 2020-01-14 18 37 37" src="https://user-images.githubusercontent.com/42843963/72332286-1e3a8980-36fd-11ea-982d-387bd243e6ca.png">

### 追加後
<img width="1403" alt="スクリーンショット 2020-01-14 18 38 43" src="https://user-images.githubusercontent.com/42843963/72332288-1f6bb680-36fd-11ea-97ee-73108734c30a.png">


## 課題
- 作ったはいいものの、マテリアルデザイン的にOK？デスクトップだとNGとか、スマホだとOKとかありそう
