### PR TITLE
Fix migration file typo

### DIFF
--- a/db/migrate/20191216071145_add_columns_to_users.rb
+++ b/db/migrate/20191216071145_add_columns_to_users.rb
@@ -5,6 +5,7 @@ class AddColumnsToUsers < ActiveRecord::Migration[6.0]
     add_column :users, :provider, :string
     add_column :users, :uid, :string
     add_column :users, :name, :string
+
+    add_index :users, [:provider, :uid], unique: true
   end
-  add_index :users, [:provider, :uid], unique: true
 end


### PR DESCRIPTION
#136 

マイグレーションファイルの書き方が間違っていたので修正