### PR TITLE
Fix to show image

### DIFF
--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,8 +1,7 @@
 .container
-  / .welcome-logo-main-visual
   .welcome-logo__block--center
     .welcome-logo__image-container
-      img.welcome-logo__image src="./assets/twi-note-icon/icon-256x256.png"
+      = image_tag "twi-note-icon/icon-256x256.png", alt: ""
     = link_to new_user_session_path(), class: "welcome__block--button"
       | サインイン画面に移動
   .welcome__block
@@ -13,41 +12,20 @@
       | ついノートとは何ですか？
     p.welcome__text
       | 勉強会参加者向けの、ノート作成支援アプリです
-    / img.welcome__image src="./assets/welcome/what-does-twi-note-do.png"
   .welcome__block
     h2.welcome__sub-title
       | ついノートは何ができますか？
     p.welcome__text
       | ついノートは、勉強会での勉強をサポートします。<br>ついノートを使うことで、ユーザーは知見を貯めることができます
-    img.welcome__image src="./assets/welcome/before-and-after-using-twi-note.png"
+    = image_tag "welcome/before-and-after-using-twi-note.png", alt: "", class: "welcome__image"
   .welcome__block
     h2.welcome__sub-title
       | ついノートは何を解決してくれますか？
     p.welcome__text
       | 勉強会参加者は「交流してばかりだと、知見が溜まっていかない」という悩みを抱えています。<br>ついノートを使うことで、「交流しながら知見も溜まる」ようになります
-    img.welcome__image src="./assets/welcome/what-twi-note-can-do.png"
+    = image_tag "welcome/what-twi-note-can-do.png", alt: "", class: "welcome__image"
   .welcome__block
     h2.welcome__sub-title
       | ついノートはどうやって悩みを解決してくれますか？
     p.welcome__text
       | 勉強会用ハッシュタグのツイートを集めてノートにします
-  
-  / TODO: Add when product is complete
-  / .welcome__block
-  /   h2.welcome__sub-title
-  /     | ついノートの使い方
-  /   p.welcome__text
-  /     | 「勉強会ハッシュタグ」と「開始時刻」「終了時刻」を入力するだけで、簡単にツイートをまとめることができます
-  /   img.welcome__image src="./assets/welcome/3-steps.png"
-  
-  / TODO: Add when product is complete
-  / .welcome__block
-  /   h2.welcome__sub-title
-  /     | （【予定】画面の説明を追加）
-  /   p.welcome__text
-  /     | （【予定】説明を追加）
-
-
-
-
-


### PR DESCRIPTION
Ref: https://github.com/s4na/twi-note/issues/149

エラー

```
Failed to load resource: the server responded with a status of 404 (Not Found)
what-twi-note-can-do.png:1 Failed to load resource: the server responded with a status of 404 (Not Found)
before-and-after-using-twi-note.png:1 Failed to load resource: the server responded with a status of 404 (Not Found)
```

## 状況

### Top page imageのURLがおかしい


Top page
`http://twi-note.herokuapp.com/assets/twi-note-icon/icon-256x256.png`

Sign in page image URL

`http://twi-note.herokuapp.com/assets/twi-note-icon/icon-36x36-0c3ea8ef5a47baab707bf262bd0afa5c7469b178f77fe64faeae9c2cb213b4d8.png`

### 原因：imageタグの使い方

正解
```
img.welcome-logo__image src="./assets/twi-note-icon/icon-256x256.png"
```

間違い
```
= image_tag "twi-note-icon/icon-36x36.png", alt: "twi-note icon", class: "icon-36x36"
```