### PR TITLE
Change inner-text of a-button to responsive

### DIFF
--- a/app/assets/stylesheets/molecules/_search-form-header.sass
+++ b/app/assets/stylesheets/molecules/_search-form-header.sass
@@ -1,12 +1,15 @@
 .search-form-header
-  margin-bottom: 20px
-  margin-left: 10px
-  margin-right: 10px
+  margin-bottom: 1.5rem
+  margin-left: 0.5rem
+  margin-right: 0.5rem
 
   &__items
     display: flex
     justify-content: flex-end
-    flex-wrap: wrap
+    flex-wrap: nowrap
   &__item
     margin-left: 10px
     margin-bottom: 2px
+  &__inner-text
+    @media screen and (max-width:979px)
+      display: none

--- a/app/javascript/tweets.vue
+++ b/app/javascript/tweets.vue
@@ -46,12 +46,14 @@
             button(type="button" @click="copyToClipboard()" :class="{'is-disabled': isActive ==='preview'}" :disabled="isActive ==='preview'").a-button
               i.material-icons
                 | content_copy
-              | コピー
+              .search-form-header__inner-text
+                | コピー
           .search-form-header__item
             button(type="submit").a-button.is-primary
               i.material-icons
                 | save
-              | ノートを保存
+              .search-form-header__inner-text
+                | ノートを保存
       .note
         .note__title
           label.a-label


### PR DESCRIPTION
a-buttonのinner-textが表示できない時は、アイコンのみ表示に変更

### 変更前

![スクリーンショット_2020-01-30_3_27_43](https://user-images.githubusercontent.com/42843963/73385634-d593ea80-4310-11ea-9d7e-438f82e11130.png)
### 変更後

![スクリーンショット_2020-01-30_3_27_38](https://user-images.githubusercontent.com/42843963/73385614-cf9e0980-4310-11ea-8d0f-da642915a617.png)
