### PR TITLE
Fix timezone

### DIFF
--- a/app/javascript/tweets.vue
+++ b/app/javascript/tweets.vue
@@ -13,11 +13,11 @@
           .search-form__item
             label.a-label
               | 開始日時
-            datetime(v-model="start_datetime" format="yyyy/LL/d hh:mm" type="datetime" input-id="start_datetime" name="tweets-search[start_datetime]").search-form__start-datetime.a-text-input
+            datetime(v-model="start_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" input-id="start_datetime" name="tweets-search[start_datetime]").search-form__start-datetime.a-text-input
           .search-form__item
             label.a-label
               | 終了日時
-            datetime(v-model="end_datetime" format="yyyy/LL/d hh:mm" type="datetime" input-id="end_datetime" name="tweets-search[end_datetime]").search-form__end-datetime.a-text-input
+            datetime(v-model="end_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" input-id="end_datetime" name="tweets-search[end_datetime]").search-form__end-datetime.a-text-input
           .search-form__item
             .search-form__inner--center
               button(type="button" @click="searchTweets").search-form__button.a-button.is-secondary
@@ -89,6 +89,7 @@ import moment from 'moment'
 import Tweet from 'tweet'
 import Markdown2Tweets from './markdown2tweets.js'
 import { Datetime } from 'vue-datetime'
+import { DateTime } from 'luxon';
 
 export default {
   props: {
@@ -125,10 +126,8 @@ export default {
       this.note_body = document.querySelector('#js-note-body').innerText || null
     }
 
-    const today = new Date()
-    const oneWeekBefore = moment(today).add(-7, "days").toDate()
-    this.start_datetime = oneWeekBefore.toISOString()
-    this.end_datetime = today.toISOString()
+    this.start_datetime = DateTime.local().toISO()
+    this.end_datetime = DateTime.local().minus({ days: 7 }).toISO()
 
     if (this.noteEditMode !== '' && this.noteEditMode !== null){
       this.isActive = this.noteEditMode

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ module TwiNote
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
 
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
     I18n.available_locales = [:ja, :en]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "luxon": "^1.21.3",
+    "luxon": "^1.22.0",
     "moment": "^2.24.0",
     "pug": "^2.0.4",
     "pug-plain-loader": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5492,10 +5492,10 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-luxon@^1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.21.3.tgz#f1d5c2a7e855d039836cf4954f883ecac8fc4727"
-  integrity sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw==
+luxon@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.22.0.tgz#639525c7c69e594953c7b142794466b8ea85b868"
+  integrity sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw==
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
https://github.com/s4na/twi-note/issues/222

https://qiita.com/Horie1024/items/85688099707610f70fa6

>  ▸    Release command executing: this config change will not be available until the command succeeds. Use `heroku releases:output` to view the log.

[Rails + Heroku 利用時に、レコードのタイムゾーンがずれていることに気が付いた際に確認したいこと & リカバリ方法](https://qiita.com/tetsuya/items/e0fd25fc3da2615d1cb2)

javascript `new Date()` のtimezone

最終的な原因としては、 vue-datetimeのformat間違いが原因だった。 hhが24時間ではなく12時間表記だったため。


フロントでの日付の作成をmoment.jsで

https://qiita.com/taizo/items/3a5505308ca2e303c099