### PR TITLE
Fix tweets sort

### DIFF
--- a/app/models/tweet_repository.rb
+++ b/app/models/tweet_repository.rb
@@ -76,6 +76,6 @@ class TweetRepository
     end
 
     def sort_tweet_asc
-      @tweets.sort_by! { |tweet| tweet[:created_at].to_i }
+      @tweets.reverse!
     end
 end


### PR DESCRIPTION
Ref: https://github.com/s4na/twi-note/issues/234

ツイートのレスポンスは昇順で返す必要があります。
前回の修正の変更が間違っていたので修正しました。
