### PR TITLE
Change padding size

### DIFF
--- a/app/assets/stylesheets/atoms/_card.sass
+++ b/app/assets/stylesheets/atoms/_card.sass
@@ -1,12 +1,14 @@
 .card
-  padding: 6px 18px
   border-radius: 0 0 2px 2px
-
   border-left: solid 1px $card-border-color
   border-right: solid 1px $card-border-color
   border-bottom: solid 1px $card-border-color  
   background-color: $card-background-color
 
+  @media screen and (max-width:979px)
+    padding: 0.25rem 0.5rem
+  @media screen and (min-width:980px)
+    padding: 0.5rem 1rem
   p
     word-break: break-all
 

--- a/app/assets/stylesheets/molecules/_search-form-header.sass
+++ b/app/assets/stylesheets/molecules/_search-form-header.sass
@@ -1,7 +1,5 @@
 .search-form-header
   margin-bottom: 1.5rem
-  margin-left: 0.5rem
-  margin-right: 0.5rem
 
   &__items
     display: flex

--- a/app/assets/stylesheets/organisms/_note.sass
+++ b/app/assets/stylesheets/organisms/_note.sass
@@ -1,6 +1,2 @@
-.note
-  margin-left: 0.5rem
-  margin-right: 0.5rem
-  margin-bottom: 0.5rem
-  &__title
-    margin-bottom: 1rem
+.note__title
+  margin-bottom: 1rem

--- a/app/assets/stylesheets/organisms/_search-form.sass
+++ b/app/assets/stylesheets/organisms/_search-form.sass
@@ -1,14 +1,10 @@
-.search-form__body
-  margin-bottom: 0.5rem
-
 .search-form__inner
   display: flex
   flex-direction: row
   flex-wrap: nowrap
-
-.search-form__inner--center
-  display: flex
-  justify-content: center
+  &--center
+    display: flex
+    justify-content: center
 
 .search-form__block
   display: flex
@@ -20,17 +16,25 @@
   background-color: $white
   +is-material
 
-.search-form__items
-  margin-left: 0.5rem
-  margin-right: 0.5rem
-
-.search-form__item
-  margin-bottom: 1rem
+  & > *
+    @media screen and (max-width:979px)
+      margin-left: 0.5rem
+      margin-right: 0.5rem
+      &:last-child
+        margin-bottom: 0.5rem
+    @media screen and (min-width:980px)
+      margin-left: 1rem
+      margin-right: 1rem
+      &:last-child
+        margin-bottom: 1rem
 
 .search-form__small-block
   width: 10%
   display: flex
   justify-content: center
+
+.search-form__item
+  margin-bottom: 1rem
 
 .search-form__tools
   display: flex
@@ -58,7 +62,3 @@
 .search-form__button
   width: 160px
   margin: 0 auto
-
-.search-form__result
-  margin-left: 0.5rem
-  margin-right: 0.5rem


### PR DESCRIPTION
Ref: https://github.com/s4na/twi-note/issues/233

- パディングの圧迫感を減らした。
  - 表示文字数を維持するため、スマホサイズ時はそのまま残した。

## FB

> 進んでますね！！
> 
> ぱっと見たところ、
> 
> ![image](https://user-images.githubusercontent.com/42843963/73586184-e26d3580-44ec-11ea-9aad-01ba409d2248.png)
> 
> ここのpaddingが少なくて窮屈に見えたからもう少しあると良さそう。主要となる文字のサイズ1個分くらいあると落ち着くかもです。
> 
> ボタンの中のアイコンフォントはアイコンの横に文字が来ることを想定して、アイコンの右にmarginが設定されてるかも。
> 
> ![image](https://user-images.githubusercontent.com/42843963/73586187-e7ca8000-44ec-11ea-86f9-807cfddbd596.png)
> 
> https://github.com/s4na/twi-note/blob/master/app/assets/stylesheets/atoms/_button.sass#L13
> これですね。
> 
> is-icon みたいな class を用意するしかないかなー。
> https://codepen.io/machida/pen/abzgaXG