### PR TITLE
change the initial value of isExistSearchEesult to 1

### DIFF
--- a/app/javascript/tweets.vue
+++ b/app/javascript/tweets.vue
@@ -113,7 +113,7 @@ export default {
       start_datetime: '',
       end_datetime: '',
       isActive: 'preview',
-      isExistSearchEesult: 0,
+      isExistSearchEesult: 1,
     }
   },
   created() {


### PR DESCRIPTION
- 検索結果がある（ `isExistSearchEesult` ）という変数の初期値を0から1（あり）に変更。
  - 検索前から「検索結果なし」と表示されてしまうため