### PR TITLE
Add support for setting minuteStep of vue-datetime to 10

### DIFF
--- a/app/javascript/tweets.vue
+++ b/app/javascript/tweets.vue
@@ -13,11 +13,11 @@
           .search-form__item
             label.a-label
               | 開始日時
-            datetime(v-model="start_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" minute-step="10" input-id="start_datetime" name="tweets-search[start_datetime]").search-form__start-datetime.a-text-input
+            datetime(v-model="start_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" :minute-step="minuteStep" input-id="start_datetime" name="tweets-search[start_datetime]").search-form__start-datetime.a-text-input
           .search-form__item
             label.a-label
               | 終了日時
-            datetime(v-model="end_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" minute-step="10" input-id="end_datetime" name="tweets-search[end_datetime]").search-form__end-datetime.a-text-input
+            datetime(v-model="end_datetime" format="yyyy/LL/d HH:mm" zone="Asia/Tokyo" type="datetime" :minute-step="minuteStep" input-id="end_datetime" name="tweets-search[end_datetime]").search-form__end-datetime.a-text-input
           .search-form__item
             .search-form__inner--center
               button(type="button" @click="searchTweets").search-form__button.a-button.is-secondary#search-form__button
@@ -89,7 +89,7 @@ import moment from 'moment'
 import Tweet from 'tweet'
 import Markdown2Tweets from './markdown2tweets.js'
 import { Datetime } from 'vue-datetime'
-import { DateTime } from 'luxon';
+import { DateTime } from 'luxon'
 
 export default {
   props: {
@@ -125,8 +125,14 @@ export default {
       this.note_body = document.querySelector('#js-note-body').innerText || null
     }
 
-    this.start_datetime = DateTime.local().minus({ days: 7 }).toISO()
-    this.end_datetime = DateTime.local().toISO()
+    this.start_datetime = DateTime.local()
+      .minus({ hour: 1 })
+      .minus({ minute: DateTime.local().minute % this.minuteStep })
+      .toISO()
+    
+    this.end_datetime = DateTime.local()
+      .minus({ minute: DateTime.local().minute % this.minuteStep })
+      .toISO()
 
     if (this.noteEditMode !== '' && this.noteEditMode !== null){
       this.isActive = this.noteEditMode
@@ -202,6 +208,7 @@ export default {
     }
   },
   computed: {
+    minuteStep: () => 10,
     tweetsString() {
       return JSON.stringify(this.note_tweets, null, 2)
     },


### PR DESCRIPTION
- vue-datetimeのminuteStepを10に変更したことに対して、一部未対応でありエラーが発生していたため、対応
  - start_datetime, end_datetimeの初期値の分が10分単位になるように変更
- start_datetime, end_datetimeの差分を7日だと長すぎるので、1時間に変更。