### PR TITLE
Fix style to welcome-page

### DIFF
--- a/app/assets/stylesheets/pages/_welcome.sass
+++ b/app/assets/stylesheets/pages/_welcome.sass
@@ -47,7 +47,7 @@
   align-items: center
   flex-direction: row
   flex-wrap: wrap
-  justify-content: space-around
+  justify-content: space-between
 
   min-height: 250px
 
@@ -55,7 +55,7 @@
   @media screen and (max-width:799px)
     width: 100%
   @media screen and (min-width:800px)
-    width: 50%
+    width: 47%
   
   & .welcome__text
     width: 100%
@@ -126,8 +126,9 @@
   justify-content: center
   margin-bottom: 1rem
 
-  & > *
+  & > img
     width: 100%
+    height: 100%
     max-height: 230px
     height: auto
 

--- a/app/views/application/_footer.slim
+++ b/app/views/application/_footer.slim
@@ -5,5 +5,5 @@
     = link_to "プライバシーポリシー", privacy_policies_path
     = link_to "免責事項", disclaimers_path
   .footer__block
-    = link_to "Twitter：@s4na_penguin", "https://twitter.com/s4na_penguin"
-    = link_to "GitHub：s4na/twi-note", "https://github.com/s4na/twi-note"
+    = link_to "ソースコード(GitHub)", "https://github.com/s4na/twi-note"
+    = link_to "連絡先(Twitter)", "https://twitter.com/s4na_penguin"


### PR DESCRIPTION
welcomeページ修正

- 文字と画像の間に間を開けた
![スクリーンショット_2020-02-09_16_16_16](https://user-images.githubusercontent.com/42843963/74098134-c9512e00-4b57-11ea-8f89-7997abf91dca.png)


- footerの文章を修正し、目的ベースでたどり着けるように変更
  - 例：Twitter 👉 連絡先
![スクリーンショット_2020-02-09_16_15_41](https://user-images.githubusercontent.com/42843963/74098122-a7f04200-4b57-11ea-9194-ffa95d36c55e.png)

