### PR TITLE
fix img style to welcome__image

### DIFF
--- a/app/assets/stylesheets/pages/_welcome.sass
+++ b/app/assets/stylesheets/pages/_welcome.sass
@@ -127,8 +127,7 @@
   margin-bottom: 1rem
 
   & > img
-    width: 100%
-    height: 100%
+    max-width: 100%
     max-height: 230px
     height: auto
 


### PR DESCRIPTION
https://github.com/s4na/twi-note/issues/274

machidaさんFBの画像が横に伸びているのを修正

## machidaさんFB

> 画像が横に伸びてしまっているので、こうすると直ります。

![image](https://user-images.githubusercontent.com/42843963/74307671-5939e680-4da9-11ea-8ab0-2be7ab95acfa.png)

![image](https://user-images.githubusercontent.com/42843963/74307660-5212d880-4da9-11ea-8af1-5116797b4601.png)
