### PR TITLE
Fix h1 & logo

### DIFF
--- a/app/assets/stylesheets/pages/_welcome.sass
+++ b/app/assets/stylesheets/pages/_welcome.sass
@@ -134,6 +134,7 @@
 
 .welcome__title
   margin-bottom: 1rem
+  text-align: center
   @media screen and (max-width:799px)
     font-size: 1.6rem
   @media screen and (min-width:800px)

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,11 +1,11 @@
 .welcome__block
   .welcome__container--center
+    .welcome-logo__image-container
+      = image_tag "twi-note-icon/icon-196x196.png", alt: ""
     h1.welcome__title
       | 勉強会のノートをもっと簡単に。
       br
       | 知見をもっと共有したい
-    .welcome-logo__image-container
-      = image_tag "twi-note-icon/icon-196x196.png", alt: ""
     = link_to new_user_session_path(), class: "welcome__button"
       | サインイン画面に移動
 .welcome__block


### PR DESCRIPTION
## 変更点

- キャッチコピーを真ん中寄せ
- h1とロゴの場所を入れ替え

## machidaさんFB内容

https://github.com/s4na/twi-note/issues/281

> キャッチコピーは真ん中寄せの方が綺麗になりそうです。

![image](https://user-images.githubusercontent.com/42843963/74306867-25f65800-4da7-11ea-8629-0f511ad14b01.png)

https://github.com/s4na/twi-note/issues/282

> アイコン、キャッチコピーの場所変更。キャッチコピーはアイコンの下

![image](https://user-images.githubusercontent.com/42843963/74306849-170fa580-4da7-11ea-94aa-78d5dacfd274.png)