### PR TITLE
Add note download as text

### DIFF
--- a/app/assets/stylesheets/molecules/_note-show.sass
+++ b/app/assets/stylesheets/molecules/_note-show.sass
@@ -12,12 +12,11 @@
     display: flex
     justify-content: flex-end
   &__item
-    
     min-width: 9rem
     margin-left: 1rem
-    button
-      min-width: 9rem
-      height: 2.35rem
+    .a-button
+      padding-left: 2rem
+      padding-right: 2rem
   &__text
     padding: 20px 0
     white-space: pre-wrap

--- a/app/controllers/notes/download_controller.rb
+++ b/app/controllers/notes/download_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Notes::DownloadController < ApplicationController
+  before_action :authenticate_user!, only: [:show]
+  before_action :set_note, only: [:show]
+
+  def show
+    respond_to do |format|
+      format.text { text_export }
+    end
+  end
+
+  private
+    def set_note
+      @note = current_user.notes.find(params[:id])
+    end
+
+    def note_params
+      params.require(:note).permit(
+        :title, :body, :tweets, :all_search_result_tweets, :edit_mode,
+        search_setting_attributes: [:query, :start_datetime, :end_datetime]
+      )
+    end
+
+    def text_export
+      if @note.title.nil?
+        send_data(
+          "#{@note.body}\n",
+          filename: "note.text"
+        )
+      else
+        send_data(
+          "# #{@note.title}\n\n#{@note.body}\n",
+          filename: "#{@note.title}.text"
+        )
+      end
+    end
+end

--- a/app/javascript/tweets.vue
+++ b/app/javascript/tweets.vue
@@ -66,7 +66,7 @@
           .search-form-header__item
             button(type="submit").a-button.is-primary
               i.material-icons
-                | note
+                | cloud_upload
               .search-form-header__inner-text
                 | 保存
       .note

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -4,7 +4,11 @@
       h1.note-show__title
         = @note.title
       .note-show__items
-        #js-note-body-copy
+        .note-show__item
+          = link_to "#{notes_download_path(@note)}.txt", class: "a-button"
+            i.material-icons
+              | file_download
+            | ダウンロード
         .note-show__item
           = link_to edit_note_path(@note), class: "a-button is-warning"
             i.material-icons

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks", only: %i(post)
   }
 
+  namespace "notes" do
+    resources :download, only: %i(show)
+  end
+
   resources :notes
   resources :privacy_policies, only: %i(index)
   resources :disclaimers, only: %i(index)


### PR DESCRIPTION
## ノートをテキストとしてダウンロードできるように修正

ダウンロードボタンをクリックすると、

<img width="960" alt="スクリーンショット_2020-02-14_20_16_50" src="https://user-images.githubusercontent.com/42843963/74526576-fe4dee00-4f66-11ea-9413-b6606323c516.png">

ノートの内容がテキストファイルとして保存される。
ノートのタイトルがファイル名になる

<img width="238" alt="スクリーンショット 2020-02-14 20 16 40" src="https://user-images.githubusercontent.com/42843963/74526565-faba6700-4f66-11ea-8842-dd0072b13333.png">

## ついでに、保存ボタンのアイコンを変更

<img width="162" alt="スクリーンショット 2020-02-14 20 15 00" src="https://user-images.githubusercontent.com/42843963/74526405-b202ae00-4f66-11ea-9115-fff4a545cd83.png">
