### PR TITLE
fix style to welcome__image > img max-height

### DIFF
--- a/app/assets/stylesheets/pages/_welcome.sass
+++ b/app/assets/stylesheets/pages/_welcome.sass
@@ -145,6 +145,7 @@
 
   & > img
     max-width: 100%
+    max-height: 230px
     height: auto
 
 .welcome__title


### PR DESCRIPTION
https://github.com/s4na/twi-note/issues/288

iPhoneでみた時のサイズがおかしいので、"welcome__image > img" のmax-heightを調整