### PR TITLE
Fix align-items center to swiper-slide

### DIFF
--- a/app/assets/stylesheets/blocks/swiper/_swiper.sass
+++ b/app/assets/stylesheets/blocks/swiper/_swiper.sass
@@ -35,5 +35,8 @@
   text-align: center
 
   a
+    display: flex
     width: 50%
     justify-content: center
+    text-align: center
+    align-items: center


### PR DESCRIPTION
https://github.com/s4na/twi-note/issues/288

swiper-slideのアイコンとテキストの高さが揃っていなかったので、修正