### PR TITLE
Cut out webmock as helper

### DIFF
--- a/test/models/tweet_repository_test.rb
+++ b/test/models/tweet_repository_test.rb
@@ -1,43 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "webmock/minitest"
 
 class TweetRepositoryTest < ActiveSupport::TestCase
   test "#search" do
-    # get oauth token
-    stub_request(:post, "https://api.twitter.com/oauth2/token")
-      .with(
-        body: { "grant_type"=>"client_credentials" },
-        headers: { "Connection"=>"close" }
-      )
-      .to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: { 'Content-Type': "application/json; charset=utf-8" }
-      )
-
-    # get twitter response
-    stub_request(:get, "https://api.twitter.com/1.1/search/tweets.json?count=100&exclude=retweets&q=hoge&result_type=recent&since_id&until=2020-02-19")
-      .with(headers: { "Connection"=>"close" })
-      .to_return(
-        status: 200,
-        body:
-          {
-            statuses: [
-              {
-                created_at: "Tue Feb 18 23:59:57 +0000 2020",
-                id: 1229918506226864128,
-                id_str: "1229918506226864128",
-                text: "そろそろリモートワークやらフレックスやら活用していきたいゾ",
-                user: {
-                  id_str: "3018621859",
-                },
-              }
-            ]
-          }.to_json,
-        headers: { 'Content-Type': "application/json; charset=utf-8" }
-      )
+    mock_twitter_search_results!
 
     tweets = TweetRepository.new("id", "secret")
       .search(
@@ -57,6 +24,7 @@ class TweetRepositoryTest < ActiveSupport::TestCase
         start_datetime: "2020-02-16 10:00",
         end_datetime: "2020-02-19 11:00",
       )
+
     assert_equal "次回は神速さん！！！ #ginzarails", tweets.first[:text]
   end
 end

--- a/test/supports/webmock_helper.rb
+++ b/test/supports/webmock_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module WebmockHelper
+  def mock_twitter_search_results!
+    # twitter oauth token
+    stub_request(:post, "https://api.twitter.com/oauth2/token")
+      .with(
+        body: { "grant_type"=>"client_credentials" },
+        headers: { "Connection"=>"close" }
+      )
+      .to_return(
+        status: 200,
+        body: {}.to_json,
+        headers: { 'Content-Type': "application/json; charset=utf-8" }
+      )
+    # return twitter response
+    stub_request(:get, "https://api.twitter.com/1.1/search/tweets.json?count=100&exclude=retweets&q=hoge&result_type=recent&since_id&until=2020-02-19")
+      .with(headers: { "Connection"=>"close" })
+      .to_return(
+        status: 200,
+        body:
+          {
+            statuses: [
+              {
+                created_at: "Tue Feb 18 23:59:57 +0000 2020",
+                id: 1229918506226864128,
+                id_str: "1229918506226864128",
+                text: "そろそろリモートワークやらフレックスやら活用していきたいゾ",
+                user: {
+                  id_str: "3018621859",
+                },
+              }
+            ]
+          }.to_json,
+        headers: { 'Content-Type': "application/json; charset=utf-8" }
+      )
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,8 @@ require "webmock/minitest"
 require "supports/webmock_helper"
 
 WebMock.disable_net_connect!(
-  allow_localhost: true
+  allow_localhost: true,
+  allow: "chromedriver.storage.googleapis.com"
 )
 
 class ActiveSupport::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,12 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "minitest/autorun"
+require "webmock/minitest"
+require "supports/webmock_helper"
+
+WebMock.disable_net_connect!(
+  allow_localhost: true
+)
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
@@ -13,4 +19,5 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  include WebmockHelper
 end


### PR DESCRIPTION
https://github.com/s4na/twi-note/issues/311

- テスト内のWebmockの処理をヘルパーとして切り出し。