### PR TITLE
Fix typo to envs(twitter was mistaken for twittwe)

### DIFF
--- a/app/controllers/api/tweets_controller.rb
+++ b/app/controllers/api/tweets_controller.rb
@@ -4,7 +4,7 @@ class Api::TweetsController < ApplicationController
   before_action :set_api_tweet, only: [:show, :edit, :update, :destroy]
 
   def index
-    tweet = TweetRepository.new(ENV["TWITTWE_APP_ID"], ENV["TWITTWE_APP_SECRET"])
+    tweet = TweetRepository.new(ENV["TWITTER_APP_ID"], ENV["TWITTER_APP_SECRET"])
     @tweets = tweet.search(params)
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -261,9 +261,9 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   if Rails.env.production?
-    config.omniauth :twitter, ENV["TWITTWE_APP_ID"], ENV["TWITTWE_APP_SECRET"], callback_url: "https://twi-note.herokuapp.com/users/omniauth_callbacks"
+    config.omniauth :twitter, ENV["TWITTER_APP_ID"], ENV["TWITTER_APP_SECRET"], callback_url: "https://twi-note.herokuapp.com/users/omniauth_callbacks"
   else
-    config.omniauth :twitter, ENV["TWITTWE_APP_ID"], ENV["TWITTWE_APP_SECRET"], callback_url: "http://localhost:3000/users/omniauth_callbacks"
+    config.omniauth :twitter, ENV["TWITTER_APP_ID"], ENV["TWITTER_APP_SECRET"], callback_url: "http://localhost:3000/users/omniauth_callbacks"
   end
 
 


### PR DESCRIPTION
環境変数名が間違っていたので修正
※Heroku側も修正済