### PR TITLE
Add user follow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 yarn-debug.log*
 .yarn-integrity
 .env*
+TAGS

--- a/Gemfile
+++ b/Gemfile
@@ -49,16 +49,20 @@ group :test do
   gem "webmock"
 end
 
-# not default
+group :development, :test do
+  gem "sqlite3", "~> 1.4"
+end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Not default
 
 group :development, :test do
+  # Pry
   gem "pry-rails"
   gem "pry-byebug"
   gem "pry-doc"
-  gem "sqlite3", "~> 1.4"
+
+  # Test
   gem "rspec-rails"
   gem "factory_bot_rails"
 end
@@ -68,26 +72,45 @@ group :production do
 end
 
 group :development do
+  # Lint
   gem "rubocop", require: false
   gem "rubocop-rails"
   gem "rubocop-performance"
+
+  # Lint
   gem "slim_lint"
   gem "html2slim"
+
+  # N+1
   gem "bullet"
 end
 
+# Tamplate
 gem "slim-rails"
+
+# I18n
 gem "rails-i18n", "~> 6.0.0"
+gem "i18n-js"
+
+# Twitter API
 gem "twitter"
+
+# .env
 gem "dotenv-rails"
-gem "jquery-rails"
+
+# Devise
 gem "devise"
 gem "devise-i18n"
+
+# Omniauth
 gem "omniauth"
 gem "omniauth-twitter"
 gem "omniauth-rails_csrf_protection"
 
+# JavaScript
+gem "jquery-rails"
 gem "materialize-sass", "~> 1.0.0"
 gem "material_icons"
-gem "i18n-js"
+
+# Pagination
 gem "kaminari"

--- a/app/assets/stylesheets/atoms/_button.sass
+++ b/app/assets/stylesheets/atoms/_button.sass
@@ -1,13 +1,22 @@
 .a-button
-  display: flex
   height: 40px
   padding: 0.25em 0.5em
   border-radius: 4px
+  
+  display: flex
   justify-content: center
   align-items: center
   font-weight: bold
   text-decoration: none
   outline: none
+  
+  button
+    display: flex
+    justify-content: center
+    align-items: center
+    font-weight: bold
+    text-decoration: none
+    outline: none
 
   img
     margin-right: 0.2em
@@ -27,6 +36,10 @@
     +button-color($disabled-color)
     box-shadow: none
     cursor: pointer
+
+  &.add-padding
+    padding-left: 2rem
+    padding-right: 2rem
 
   @media screen and (min-width:980px)
     min-width: 4.5em

--- a/app/assets/stylesheets/blocks/list/_list.sass
+++ b/app/assets/stylesheets/blocks/list/_list.sass
@@ -1,0 +1,27 @@
+.list
+  min-height: 4rem
+  padding-left: 1rem
+  padding-right: 1rem
+  font-size: 20px
+  
+  border-right: 0.5px solid #9e9e9e
+  border-left: 0.5px solid #9e9e9e
+  border-bottom: 0.5px solid #9e9e9e
+  font-weight: bold
+
+  align-items: center
+  display: flex
+
+  a
+    display: inline-block
+    padding-top: 1rem
+    padding-bottom: 1rem
+    width: 100%
+
+  &:first-child
+    border-top: 0.5px solid #9e9e9e
+
+  &:nth-child(even)
+    background-color: #f1eced
+
+.lists

--- a/app/assets/stylesheets/blocks/note/_note-show.sass
+++ b/app/assets/stylesheets/blocks/note/_note-show.sass
@@ -2,6 +2,7 @@
   +is-material
   background-color: $white
   padding: 1rem
+  margin-bottom: 1rem
   
   &__title
     margin-bottom: 10px

--- a/app/assets/stylesheets/blocks/page/_page.sass
+++ b/app/assets/stylesheets/blocks/page/_page.sass
@@ -17,6 +17,10 @@
   &__sub-title
     margin-bottom: 1rem
 
+.page__link
+  display: flex
+  justify-content: center
+
 .page-item-button
   display: flex
   justify-content: flex-end

--- a/app/assets/stylesheets/blocks/profile/_profile.sass
+++ b/app/assets/stylesheets/blocks/profile/_profile.sass
@@ -1,0 +1,44 @@
+.profile
+  
+  display: flex
+  flex-direction: column
+  align-items: center
+  padding-top: 2rem
+  justify-content: center
+  padding-bottom: 2rem
+.profile__block
+  display: flex
+  flex-direction: row
+  padding-bottom: 1rem
+  align-items: center
+
+  
+.profile__name
+  font-size: 34px
+  margin-left: 1rem
+  margin-right: 1rem
+
+.profile__button
+  margin-left: 1rem
+  margin-right: 1rem
+
+.profile__card
+  &-inner
+    display: flex
+    flex-direction: row
+  &-inner > *
+    display: flex
+    align-items: center
+    margin-left: 0.5rem
+    margin-right: 0.5rem
+  &-text
+    font-size: 28px
+  &-number
+    font-size: 34px
+    
+    font-weight: bold
+
+.profile__link
+  display: flex
+  justify-content: center
+  font-size: 16px

--- a/app/controllers/followings/notes_controller.rb
+++ b/app/controllers/followings/notes_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Followings::NotesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    followings = current_user.followings.includes(:notes)
+    @notes = followings.map { |u| u.notes }.flatten
+  end
+end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class FollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    other_user = User.find(params[:followee_id])
+    current_user.follow(other_user)
+    redirect_back fallback_location: root_path, notice: t(".created")
+  end
+
+  def destroy
+    Follow.destroy(params[:id])
+    redirect_back fallback_location: root_path, notice: t(".destroyed")
+  end
+end

--- a/app/controllers/notes/download_controller.rb
+++ b/app/controllers/notes/download_controller.rb
@@ -12,7 +12,7 @@ class Notes::DownloadController < ApplicationController
 
   private
     def set_note
-      @note = current_user.notes.find(params[:id])
+      @note = Note.find(params[:id])
     end
 
     def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,7 +2,8 @@
 
 class NotesController < ApplicationController
   before_action :authenticate_user!, only: [:show, :new, :edit, :create, :update, :destroy]
-  before_action :set_note, only: [:show, :edit, :update, :destroy]
+  before_action :set_note, only: [:show]
+  before_action :set_current_user_note, only: [:edit, :update, :destroy]
 
   CONTENTS_NUM = 10
   def index
@@ -50,6 +51,10 @@ class NotesController < ApplicationController
 
   private
     def set_note
+      @note = Note.find(params[:id])
+    end
+
+    def set_current_user_note
       @note = current_user.notes.find(params[:id])
     end
 

--- a/app/controllers/users/followers_controller.rb
+++ b/app/controllers/users/followers_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Users::FollowersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @users = User.find(params[:user_id]).followers
+  end
+end

--- a/app/controllers/users/followings_controller.rb
+++ b/app/controllers/users/followings_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Users::FollowingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @users = User.find(params[:user_id]).followings
+  end
+end

--- a/app/controllers/users/notes_controller.rb
+++ b/app/controllers/users/notes_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Users::NotesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @user = User.includes(:notes).find(params[:user_id])
+    @notes = @user.notes
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UsersHelper
+  def follow_or_unfollow(other_user)
+    unless other_user == current_user
+      follow = current_user.follows.find_by(followee: other_user)
+
+      if follow
+        button_to follow, method: :delete, class: "a-button is-primary add-padding" do
+          # content_tag(:div, "person_outline", class: "i material-icons") + "フォロー中"
+          "フォロー中"
+        end
+
+        # i.material-icons.global-nav-item__image
+        #   | people
+      else
+        button_to [:follows, followee_id: other_user.id], class: "a-button is-primary add-padding" do
+          # content_tag(:div, "person_add", class: "i material-icons") + "フォローする"
+          "フォローする"
+        end
+      end
+    end
+  end
+end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Follow < ApplicationRecord
+  belongs_to :user
+  belongs_to :followee, class_name: "User"
+
+  validates :user_id, presence: true
+  validates :followee_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  has_many :notes,      dependent: :destroy
+  has_many :notes, dependent: :destroy
+  has_many :follows, dependent: :destroy
+
+  has_many :followings, through: :follows, source: :followee
+  has_many :reverse_of_follows, class_name: "Follow", foreign_key: "followee_id"
+  has_many :followers, through: :reverse_of_follows, source: :user
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -22,6 +27,17 @@ class User < ApplicationRecord
     end
 
     user
+  end
+
+  def follow(other_user)
+    unless self == other_user
+      self.follows.find_or_create_by(followee: other_user)
+    end
+  end
+
+  def unfollow(other_user)
+    follow = self.follows.find_by(followee: other_user)
+    follow.destroy if follow
   end
 
   private

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,13 +10,25 @@ nav.global-nav
           = link_to notes_path, class: "global-nav-item__link a-link" do
             i.material-icons.global-nav-item__image
               | list
-            | ノート一覧
+            = t "notes_path"
+      li.global-nav__item
+        .global-nav-item__inner
+          = link_to followings_notes_path, class: "global-nav-item__link a-link" do
+            i.material-icons.global-nav-item__image
+              | timeline
+            = t "followings_notes_path"
+      li.global-nav__item
+        .global-nav-item__inner
+          = link_to users_path, class: "global-nav-item__link a-link" do
+            i.material-icons.global-nav-item__image
+              | people
+            = t "users_path"
       li.global-nav__item
         .global-nav-item__inner
           = link_to destroy_user_session_path, method: :delete, class: "global-nav-item__link a-link"  do
             i.material-icons.global-nav-item__image
               | exit_to_app
-            | ログアウト
+            = t "destroy_user_session_path"
     #global-nav__drawer
       input#global-nav__input.global-nav__unshown(type="checkbox")
       label#global-nav__open(for="global-nav__input")
@@ -28,13 +40,21 @@ nav.global-nav
             = link_to notes_path, class: "global-nav-content__item" do
               i.material-icons
                 | list
-              | ノート一覧
+              = t "notes_path"
+            = link_to followings_notes_path, class: "global-nav-content__item" do
+              i.material-icons
+                | timeline
+              = t "followings_notes_path"
+            = link_to users_path, class: "global-nav-content__item" do
+              i.material-icons
+                | people
+              = t "users_path"
             = link_to destroy_user_session_path, method: :delete, class: "global-nav-content__item"  do
               i.material-icons
                 | exit_to_app
-              | ログアウト
+              = t "destroy_user_session_path"
           - unless user_signed_in?
             = link_to root_path, class: "global-nav-content__item"  do
               i.material-icons.global-nav-item__image
                 | home
-              | トップに戻る
+              = t "root_path"

--- a/app/views/application/_meta_tags.slim
+++ b/app/views/application/_meta_tags.slim
@@ -1,4 +1,5 @@
 meta name="viewport" content="width=device-width, initial-scale=1.0"
 link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/yakuhanjp@3.3.1/dist/css/yakuhanjp.min.css"
-link href="https://fonts.googleapis.com/css?family=M+PLUS+1p&display=swap" rel="stylesheet"
-link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap" rel="stylesheet"
+- unless Rails.env == "test"
+  link href="https://fonts.googleapis.com/css?family=M+PLUS+1p&display=swap" rel="stylesheet"
+  link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP&display=swap" rel="stylesheet"

--- a/app/views/followings/notes/index.html.slim
+++ b/app/views/followings/notes/index.html.slim
@@ -1,0 +1,11 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1 フォローしてるユーザーのノート一覧
+    .page__block
+      = render "notes/lists"
+    .page__block
+      .page__link
+        = link_to 'javascript:history.back()', class: "a-button"
+          = t "go-back-to-previous-page"

--- a/app/views/followings/notes/index.html.slim
+++ b/app/views/followings/notes/index.html.slim
@@ -7,5 +7,5 @@
       = render "notes/lists"
     .page__block
       .page__link
-        = link_to 'javascript:history.back()', class: "a-button"
+        = link_to "javascript:history.back()", class: "a-button"
           = t "go-back-to-previous-page"

--- a/app/views/notes/_lists.html.slim
+++ b/app/views/notes/_lists.html.slim
@@ -1,0 +1,7 @@
+.thread
+  .thread__block
+    .lists
+      - @notes.each do |note|
+        .list
+          = link_to note_path(note)
+            = note.title

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -9,13 +9,18 @@
             i.material-icons
               | file_download
             | ダウンロード
-        .note-show__item
-          = link_to edit_note_path(@note), class: "a-button is-warning"
-            i.material-icons
-              | edit
-            | 編集
-
+        - if current_user == @note.user
+          .note-show__item
+            = link_to edit_note_path(@note), class: "a-button is-warning"
+              i.material-icons
+                | edit
+              | 編集
     .cards
       .note-show__card
         p#note-show__text.note-show__text
           = @note.body
+
+  .page__block
+    .page__link
+      = link_to 'javascript:history.back()', class: "a-button add-padding"
+        = t "go-back-to-previous-page"

--- a/app/views/notes/show.html.slim
+++ b/app/views/notes/show.html.slim
@@ -22,5 +22,5 @@
 
   .page__block
     .page__link
-      = link_to 'javascript:history.back()', class: "a-button add-padding"
+      = link_to "javascript:history.back()", class: "a-button add-padding"
         = t "go-back-to-previous-page"

--- a/app/views/users/_lists.html.slim
+++ b/app/views/users/_lists.html.slim
@@ -1,0 +1,5 @@
+.lists
+  - @users.each do |user|
+    .list
+      = link_to user_path(user)
+        = user.name

--- a/app/views/users/followers/index.html.slim
+++ b/app/views/users/followers/index.html.slim
@@ -1,0 +1,13 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1 フォロワー一覧
+    .page__block
+      .thread
+        .thread__block
+          = render "users/lists"
+    .page__block
+      .page__link
+        = link_to 'javascript:history.back()', class: "a-button add-padding"
+          = t "go-back-to-previous-page"

--- a/app/views/users/followers/index.html.slim
+++ b/app/views/users/followers/index.html.slim
@@ -9,5 +9,5 @@
           = render "users/lists"
     .page__block
       .page__link
-        = link_to 'javascript:history.back()', class: "a-button add-padding"
+        = link_to "javascript:history.back()", class: "a-button add-padding"
           = t "go-back-to-previous-page"

--- a/app/views/users/followings/index.html.slim
+++ b/app/views/users/followings/index.html.slim
@@ -1,0 +1,13 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1 フォロー一覧
+    .page__block
+      .thread
+        .thread__block
+          = render "users/lists"
+    .page__block
+      .page__link
+        = link_to 'javascript:history.back()', class: "a-button add-padding"
+          = t "go-back-to-previous-page"

--- a/app/views/users/followings/index.html.slim
+++ b/app/views/users/followings/index.html.slim
@@ -9,5 +9,5 @@
           = render "users/lists"
     .page__block
       .page__link
-        = link_to 'javascript:history.back()', class: "a-button add-padding"
+        = link_to "javascript:history.back()", class: "a-button add-padding"
           = t "go-back-to-previous-page"

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,0 +1,13 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1 ユーザー一覧
+    .page__block
+      .thread
+        .thread__block
+          = render "users/lists"
+    .page__block
+      .page__link
+        = link_to 'javascript:history.back()', class: "a-button add-padding"
+          = t "go-back-to-previous-page"

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -9,5 +9,5 @@
           = render "users/lists"
     .page__block
       .page__link
-        = link_to 'javascript:history.back()', class: "a-button add-padding"
+        = link_to "javascript:history.back()", class: "a-button add-padding"
           = t "go-back-to-previous-page"

--- a/app/views/users/notes/index.html.slim
+++ b/app/views/users/notes/index.html.slim
@@ -8,5 +8,5 @@
       = render "notes/lists"
     .page__block
       .page__link
-        = link_to 'javascript:history.back()', class: "a-button add-padding"
+        = link_to "javascript:history.back()", class: "a-button add-padding"
           = t "go-back-to-previous-page"

--- a/app/views/users/notes/index.html.slim
+++ b/app/views/users/notes/index.html.slim
@@ -1,0 +1,12 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1
+          = "#{@user.name}のノート一覧"
+    .page__block
+      = render "notes/lists"
+    .page__block
+      .page__link
+        = link_to 'javascript:history.back()', class: "a-button add-padding"
+          = t "go-back-to-previous-page"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -2,7 +2,7 @@
   .page__container
     .page__block
       .page__title
-        h1 ユーザープロフィール 
+        h1 ユーザープロフィール
     .page__block
       .thread
         .thread__block

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,0 +1,36 @@
+.container
+  .page__container
+    .page__block
+      .page__title
+        h1 ユーザープロフィール 
+    .page__block
+      .thread
+        .thread__block
+          .profile
+            .profile__block
+              .profile__name
+                = @user.name
+              - unless @user == current_user
+                .profile__button
+                  = follow_or_unfollow(@user)
+            .profile__block
+              .profile__card
+                = link_to user_followings_path(@user), class: "profile__card-inner"
+                  .profile__card-number
+                    = @user.followings.count
+                  .profile__card-text
+                    | フォロー中
+              .profile__card
+                = link_to user_followers_path(@user), class: "profile__card-inner"
+                  .profile__card-number
+                    = @user.followers.count
+                  .profile__card-text
+                    | フォロワー
+            .profile__links
+              .profile__link
+                = link_to user_notes_path(@user), class: "a-button is-secondary add-padding"
+                  = t("user_notes_path")
+    .page__block
+      .page__link
+        = link_to users_path, class: "a-button add-padding"
+          = t("users_path")

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,9 +30,11 @@ module TwiNote
 
     config.generators do |g|
       g.test_framework :rspec,
+        controller_specs: false,
         view_specs: false,
         helper_specs: false,
-        routing_specs: false
+        routing_specs: false,
+        request_specs: false
     end
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,13 +1,4 @@
 ja:
-  date:
-    formats:
-      default: "%Y年%m月%d日"
-  time:
-    formats:
-      default: "%Y年%m月%d日(%a) %H時%M分"
-      ymdhm_hy: "%Y-%m-%d %H:%M"
-      ymdhm_sla: "%Y/%m/%d %H:%M"
-      ymd_hy: "%Y-%m-%d"
   activerecord:
     models:
       note: ノート
@@ -31,3 +22,24 @@ ja:
       next: "次 &rsaquo;"
       previous: "&lsaquo; 前"
       truncate: "&hellip;"
+  date:
+    formats:
+      default: "%Y年%m月%d日"
+  time:
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分"
+      ymdhm_hy: "%Y-%m-%d %H:%M"
+      ymdhm_sla: "%Y/%m/%d %H:%M"
+      ymd_hy: "%Y-%m-%d"
+  follows:
+    create:
+      created: "フォローしました"
+    destroy:
+      destroyed: "フォロー解除しました"
+  user_notes_path: "ユーザーのノート一覧"
+  notes_path: "ノート一覧"
+  users_path: "ユーザー一覧"
+  followings_notes_path: "タイムライン"
+  root_path: "トップに戻る"
+  destroy_user_session_path: "ログアウト"
+  go-back-to-previous-page: "一つ前のページに戻る"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,20 +2,32 @@
 
 Rails.application.routes.draw do
   root to: "notes#index"
-
-  devise_for :users, only: [:sessions, :omniauth_callbacks], controllers: {
-    omniauth_callbacks: "users/omniauth_callbacks", only: %i(post)
-  }
-
-  namespace "notes" do
-    resources :download, only: %i(show)
-  end
-
-  resources :notes
   resources :privacy_policies, only: %i(index)
   resources :disclaimers, only: %i(index)
 
   namespace "api" do
     resources :tweets, only: %i(index)
   end
+
+  devise_for :users, only: [:sessions, :omniauth_callbacks], controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks", only: %i(post)
+  }
+
+  resources "users" do
+    resources "followings", only: %i(index), controller: "users/followings"
+    resources "followers", only: %i(index), controller: "users/followers"
+    resources "notes", only: %i(index), controller: "users/notes"
+  end
+
+  namespace "notes" do
+    resources :download, only: %i(show)
+  end
+
+  namespace "followings" do
+    resources "notes", only: %i(index)
+  end
+
+  resources :users, only: %i(index show)
+  resources :notes
+  resources :follows, only: %i(create destroy)
 end

--- a/db/migrate/20200313064805_create_follows.rb
+++ b/db/migrate/20200313064805_create_follows.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateFollows < ActiveRecord::Migration[6.0]
+  def change
+    create_table :follows do |t|
+      t.references :user, foreign_key: true
+      t.references :followee, foreign_key: { to_table: :users }
+      t.index [:user_id, :followee_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_155806) do
+ActiveRecord::Schema.define(version: 2020_03_13_064805) do
+  create_table "follows", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "followee_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followee_id"], name: "index_follows_on_followee_id"
+    t.index ["user_id", "followee_id"], name: "index_follows_on_user_id_and_followee_id", unique: true
+    t.index ["user_id"], name: "index_follows_on_user_id"
+  end
+
   create_table "notes", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -50,5 +60,7 @@ ActiveRecord::Schema.define(version: 2020_02_09_155806) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "follows", "users"
+  add_foreign_key "follows", "users", column: "followee_id"
   add_foreign_key "search_settings", "notes"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,5 +3,34 @@
 require "factory_bot"
 
 user_1 = FactoryBot.create(:user, name: "s4na_penguin", uid: "1072823223190835201", email: "1072823223190835201-twitter@example.com")
-note_1 = FactoryBot.create(:note, user: user_1)
-FactoryBot.create(:search_setting, note: note_1)
+10.times.collect { |i|
+  note = FactoryBot.create(:note, user: user_1)
+  FactoryBot.create(:search_setting, note: note)
+}
+
+user_2 = FactoryBot.create(:user, name: "bob", uid: "1072823223190835202", email: "1072823223190835202-twitter@example.com")
+note_2 = FactoryBot.create(:note, user: user_2)
+FactoryBot.create(:search_setting, note: note_2)
+
+user_3 = FactoryBot.create(:user, name: "carol", uid: "1072823223190835203", email: "1072823223190835203-twitter@example.com")
+note_3 = FactoryBot.create(:note, user: user_3)
+FactoryBot.create(:search_setting, note: note_3)
+
+user_1.follow(user_2)
+user_2.follow(user_1)
+user_3.follow(user_1)
+
+10.times.collect { |i|
+  user = FactoryBot.create(:user)
+  10.times.collect { |h|
+    note = FactoryBot.create(:note, user: user)
+    FactoryBot.create(:search_setting, note: note)
+  }
+
+  user_1.follow(user)
+  user.follow(user_1)
+
+  user_2.follow(user)
+
+  user.follow(user_3)
+}

--- a/spec/factories/follows.rb
+++ b/spec/factories/follows.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :follow do
+    user
+    followee
+  end
+end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -3,10 +3,14 @@
 FactoryBot.define do
   factory :note do
     user
-    title { "sendagaya.rb" }
+    title { generate(:title) }
     edit_mode { "preview" }
     body { '> @s4na_penguin ありがとうございますー！\n> [Tsuyoshi Hoshino](https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw)\n' }
     tweets { '[{"id_str":"1237048102919389185","text":"@s4na_penguin ありがとうございますー！","url":"https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw","markdown":"> @s4na_penguin ありがとうございますー！ \n> [Tsuyoshi Hoshino](https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw)","user":{"id_str":"182727080","screen_name":"hoppiestar","name":"Tsuyoshi Hoshino"}}]' }
     all_search_result_tweets { '[{"id_str":"1237048102919389185","text":"@s4na_penguin ありがとうございますー！","url":"https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw","markdown":"> @s4na_penguin ありがとうございますー！ \n> [Tsuyoshi Hoshino](https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw)","user":{"id_str":"182727080","screen_name":"hoppiestar","name":"Tsuyoshi Hoshino"}}]' }
+  end
+
+  sequence :title do |i|
+    "Sendagayarb##{i}"
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,10 +2,22 @@
 
 FactoryBot.define do
   factory :user do
-    name { "testuser" }
-    email { "test@hoge.hoge" }
+    name { generate(:name) }
+    uid { generate(:uuid) }
+    email { generate(:email) }
     provider { "twitter" }
-    uid { 1 }
     password { "hogehoge" }
+  end
+
+  sequence :name do |i|
+    "User_#{i}"
+  end
+
+  sequence :uuid do |i|
+    "#{i}"
+  end
+
+  sequence :email do |i|
+    "#{i}-twitter@example.com"
   end
 end

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Follow, type: :model do
+  let!(:current_user) { FactoryBot.create(:user, name: "current_user", uid: "1072823223190835202", email: "1072823223190835202-twitter@example.com") }
+  let!(:other_user) { FactoryBot.create(:user, name: "other_user", uid: "1072823223190835203", email: "1072823223190835203-twitter@example.com") }
+
+  describe "フォローした時" do
+    subject! { current_user.follow(other_user) }
+
+    it { expect(current_user.follows.count).to be 1 }
+    it { expect(current_user.followings.first).to eq other_user }
+    it { expect(other_user.followers.first).to eq current_user }
+
+    describe "フォロー解除した時" do
+      subject! { current_user.unfollow(other_user) }
+
+      it { expect(current_user.follows.count).to be 0 }
+    end
+  end
+end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
   describe ".find_for_twitter_oauth" do
+    let(:user) { User.find_for_twitter_oauth(auth) }
     let(:auth) {
       OmniAuth::AuthHash.new({
         provider: "Twitter",
@@ -11,7 +12,6 @@ RSpec.describe User, type: :model do
         info: { nickname: "Alice" }
       })
     }
-    let(:user) { User.find_for_twitter_oauth(auth) }
 
     it { expect("Alice").to eq user.name }
     it { expect("1").to eq user.uid }

--- a/spec/system/api/tweets_spec.rb
+++ b/spec/system/api/tweets_spec.rb
@@ -10,12 +10,10 @@ describe "tweets", type: :system do
   let!(:note_1) { FactoryBot.create(:note, user: user_1) }
   let!(:search_setting_1) { FactoryBot.create(:search_setting, note: note_1) }
 
-  before do
-    sign_in user_1
-  end
+  before { sign_in user_1 }
 
-  context "show tweets" do
-    before do
+  context "show notes & enter start_datetime" do
+    before {
       travel_to Time.zone.parse("2021-11-24 11:22:33")
 
       visit notes_path
@@ -23,30 +21,34 @@ describe "tweets", type: :system do
 
       fill_in "note[search_setting_attributes][query]", with: search_setting_1.query
       find("#note_search_setting_attributes_start_datetime").click
-    end
+    }
 
-    it "check title" do
-      assert_text "November 2021"
+    it { assert_text "November 2021" }
 
-      find(".vdatetime-calendar__month__day", text: "16").click
-      find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
-      find(".vdatetime-time-picker__item", text: "22").click
-      find(".vdatetime-time-picker__item", text: "30").click
-      find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
+    context "enter end_datetime" do
+      before {
+        find(".vdatetime-calendar__month__day", text: "16").click
+        find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
+        find(".vdatetime-time-picker__item", text: "22").click
+        find(".vdatetime-time-picker__item", text: "30").click
+        find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
 
-      find("#note_search_setting_attributes_end_datetime").click
-      assert_text "November 2021"
+        find("#note_search_setting_attributes_end_datetime").click
+        assert_text "November 2021"
 
-      find(".vdatetime-calendar__month__day", text: "16").click
-      find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
-      find(".vdatetime-time-picker__item", text: "23").click
-      find(".vdatetime-time-picker__item", text: "30").click
-      find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
-      click_on "検索"
+        find(".vdatetime-calendar__month__day", text: "16").click
+        find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
+        find(".vdatetime-time-picker__item", text: "23").click
+        find(".vdatetime-time-picker__item", text: "30").click
+        find(".vdatetime-popup__actions__button--confirm", text: "Ok").click
+        click_on "検索"
 
-      travel_back
+        travel_back
+      }
 
-      expect(page).to have_content "Markdown、初めて見たときはフォントのせいもあってか、「ゲジゲジみたいだな」って思った記憶"
+      it "show tweet" do
+        expect(page).to have_content "Markdown、初めて見たときはフォントのせいもあってか、「ゲジゲジみたいだな」って思った記憶"
+      end
     end
   end
 end

--- a/spec/system/disclaimers_spec.rb
+++ b/spec/system/disclaimers_spec.rb
@@ -4,18 +4,10 @@ require "rails_helper"
 
 describe "disclaimers", type: :system do
   let!(:user_1) { FactoryBot.create(:user) }
-
-  before do
-    sign_in user_1
-  end
+  before { sign_in user_1 }
 
   context "show disclaimers" do
-    before do
-      visit disclaimers_path
-    end
-
-    it "check title" do
-      expect(page).to have_content "免責事項"
-    end
+    before { visit disclaimers_path }
+    it { expect(page).to have_content "免責事項" }
   end
 end

--- a/spec/system/followers_spec.rb
+++ b/spec/system/followers_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "followers", type: :system do
+  let!(:user_1) { FactoryBot.create(:user) }
+  let!(:user_2) { FactoryBot.create(:user) }
+  before { sign_in user_1 }
+
+  context "user_1 follow user_2" do
+    subject! { user_1.follow(user_2) }
+
+    context "show followers" do
+      before { visit user_followers_path(user_1) }
+      it { expect(page).to have_content "フォロワー一覧" }
+    end
+  end
+end

--- a/spec/system/followings/notes_spec.rb
+++ b/spec/system/followings/notes_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "followings_notes", type: :system do
+  let!(:user_1) { FactoryBot.create(:user) }
+
+  let!(:user_2) { FactoryBot.create(:user) }
+  let!(:note_2) { FactoryBot.create(:note, user: user_2, title: "user_2_note_title") }
+  let!(:search_setting_2) { FactoryBot.create(:search_setting, note: note_2) }
+
+  let!(:user_3) { FactoryBot.create(:user) }
+  let!(:note_3) { FactoryBot.create(:note, user: user_3, title: "user_3_note_title") }
+  let!(:search_setting_2) { FactoryBot.create(:search_setting, note: note_3) }
+
+  before {
+    sign_in user_1
+    user_1.follow(user_2)
+    user_1.follow(user_3)
+  }
+
+  context "show followings_notes" do
+    before { visit followings_notes_path }
+
+    it { expect(page).to have_content "user_2_note_title" }
+    it { expect(page).to have_content "user_3_note_title" }
+  end
+end

--- a/spec/system/followings_spec.rb
+++ b/spec/system/followings_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "followings", type: :system do
+  let!(:user_1) { FactoryBot.create(:user) }
+  let!(:user_2) { FactoryBot.create(:user) }
+  before { sign_in user_1 }
+
+  context "user_1 follow user_2" do
+    subject! { user_1.follow(user_2) }
+
+    context "show followings" do
+      before { visit user_followings_path(user_1) }
+      it { expect(page).to have_content "フォロー一覧" }
+    end
+  end
+end

--- a/spec/system/notes_spec.rb
+++ b/spec/system/notes_spec.rb
@@ -7,28 +7,20 @@ describe "note", type: :system do
   let!(:note_1) { FactoryBot.create(:note, user: user_1) }
   let!(:search_setting_1) { FactoryBot.create(:search_setting, note: note_1) }
 
-  before do
-    sign_in user_1
-  end
+  let!(:user_2) { FactoryBot.create(:user) }
+  let!(:note_2) { FactoryBot.create(:note, user: user_2) }
+  let!(:search_setting_2) { FactoryBot.create(:search_setting, note: note_2) }
+
+  before { sign_in user_1 }
 
   context "show notes" do
-    before do
-      visit notes_path
-    end
-
-    it "check title" do
-      expect(page).to have_content "ノート一覧"
-    end
+    before { visit notes_path }
+    it { expect(page).to have_content "ノート一覧" }
   end
 
   context "show note" do
-    before do
-      visit note_path(note_1)
-    end
-
-    it "check title" do
-      expect(page).to have_content note_1.title
-    end
+    before { visit note_path(note_1) }
+    it { expect(page).to have_content note_1.title }
   end
 
   context "create note" do
@@ -43,9 +35,7 @@ describe "note", type: :system do
       click_on "保存"
     end
 
-    it "check title" do
-      expect(page).to have_content "ノートを作成しました"
-    end
+    it { expect(page).to have_content "ノートを作成しました" }
   end
 
   context "update note" do
@@ -61,9 +51,7 @@ describe "note", type: :system do
       click_on "保存"
     end
 
-    it "check title" do
-      expect(page).to have_content "ノートを更新しました"
-    end
+    it { expect(page).to have_content "ノートを更新しました" }
   end
 
   context "destroy note" do
@@ -75,13 +63,16 @@ describe "note", type: :system do
       end
     end
 
-    it "check title" do
-      expect(page).to have_content "ノートを削除しました"
-    end
+    it { expect(page).to have_content "ノートを削除しました" }
   end
 
+  context "show user_2's note" do
+    before { visit note_path(note_2) }
+    it { expect(page).to have_content note_2.title }
+  end
 
-  context "when note.body is empty, check that it is empty even after converting to markdown and returning" do
+  # System test for Vue.js
+  context "when note.body is empty" do
     before do
       visit note_path(note_1)
       click_on "編集"
@@ -91,16 +82,18 @@ describe "note", type: :system do
 
       click_on "保存"
     end
+    it { expect(page).to have_content "ノートを更新しました" }
 
-    it "check title" do
-      expect(page).to have_content "ノートを更新しました"
-      click_on "編集"
+    context "check that it is empty even after converting to markdown and returning" do
+      before do
+        click_on "編集"
 
-      find('label[for="tab-preview"]').click
-      find('label[for="tab-markdown"]').click
-      click_on "保存"
+        find('label[for="tab-preview"]').click
+        find('label[for="tab-markdown"]').click
+        click_on "保存"
+      end
 
-      expect(find("#note-show__text").text).to have_content "> @s4na_penguin ありがとうございますー！ \n> [Tsuyoshi Hoshino](https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw)"
+      it { expect(find("#note-show__text").text).to have_content "> @s4na_penguin ありがとうございますー！ \n> [Tsuyoshi Hoshino](https://twitter.com/hoppiestar/status/1237048102919389185?ref_src=twsrc%5Etfw)" }
     end
   end
 end

--- a/spec/system/privacy_policies_spec.rb
+++ b/spec/system/privacy_policies_spec.rb
@@ -4,18 +4,10 @@ require "rails_helper"
 
 describe "privacy_policies", type: :system do
   let!(:user_1) { FactoryBot.create(:user) }
-
-  before do
-    sign_in user_1
-  end
+  before { sign_in user_1 }
 
   context "show privacy policies" do
-    before do
-      visit privacy_policies_path
-    end
-
-    it "check title" do
-      expect(page).to have_content "プライバシーポリシー"
-    end
+    before { visit privacy_policies_path }
+    it { expect(page).to have_content "プライバシーポリシー" }
   end
 end

--- a/spec/system/users/notes_spec.rb
+++ b/spec/system/users/notes_spec.rb
@@ -5,16 +5,14 @@ require "rails_helper"
 describe "notes", type: :system do
   let!(:user_1) { FactoryBot.create(:user) }
   let!(:user_2) { FactoryBot.create(:user) }
-  let!(:note_2) { FactoryBot.create(:note, user: user_2, title: "user_2_note_title") }
+  let!(:note_2) { FactoryBot.create(:note, user: user_2) }
   let!(:search_setting_2) { FactoryBot.create(:search_setting, note: note_2) }
+  subject! { user_1.follow(user_2) }
 
-  before {
-    sign_in user_1
-    user_1.follow(user_2)
-  }
+  before { sign_in user_1 }
 
   context "show notes" do
     before { visit user_notes_path(user_2) }
-    it { expect(page).to have_content "user_2のノート一覧" }
+    it { expect(page).to have_content "User_2のノート一覧" }
   end
 end

--- a/spec/system/users/notes_spec.rb
+++ b/spec/system/users/notes_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "notes", type: :system do
+  let!(:user_1) { FactoryBot.create(:user) }
+  let!(:user_2) { FactoryBot.create(:user) }
+  let!(:note_2) { FactoryBot.create(:note, user: user_2, title: "user_2_note_title") }
+  let!(:search_setting_2) { FactoryBot.create(:search_setting, note: note_2) }
+
+  before {
+    sign_in user_1
+    user_1.follow(user_2)
+  }
+
+  context "show notes" do
+    before { visit user_notes_path(user_2) }
+    it { expect(page).to have_content "user_2のノート一覧" }
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "followings", type: :system do
+  let!(:user_1) { FactoryBot.create(:user) }
+  let!(:user_2) { FactoryBot.create(:user) }
+  before { sign_in user_1 }
+
+  context "show users" do
+    before { visit users_path }
+    it { expect(page).to have_content "ユーザー一覧" }
+  end
+
+  context "follow user_2" do
+    before {
+      visit user_path(user_2)
+      click_on "フォローする"
+      # find("フォローする").click
+    }
+    it { expect(page).to have_content "フォローしました" }
+
+    context "unfollow user_2" do
+      before {
+        click_on "フォロー中"
+        # find("フォロー中").click
+      }
+      it { expect(page).to have_content "フォロー解除しました" }
+    end
+  end
+end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -4,12 +4,7 @@ require "rails_helper"
 
 describe "welcomes", type: :system do
   context "show welcome when user is not logged in" do
-    before do
-      visit root_path
-    end
-
-    it "check title" do
-      expect(page).to have_content "ノートにツイートを貼れるサービス"
-    end
+    before { visit root_path }
+    it { expect(page).to have_content "ノートにツイートを貼れるサービス" }
   end
 end


### PR DESCRIPTION
Ref: https://github.com/s4na/twi-note/issues/352

- [x] フォロー機能の追加
  - [x] ユーザーページ（一覧＆個別）の作成
  - [x] ユーザーのノートページ（一覧＆個別）の作成
    - [x] ノートの編集ボタンを、ログインユーザー以外から見えないように変更
    - [x] ログインユーザー以外でノートのダウンロードが行えるように変更
  - [x] フォローしたユーザー一覧の作成
  - [x] フォローしたユーザーのノート一覧作成
  - [x] ページ間移動のため、ナビゲーションなど整備


## 用語
  - follower フォローする人
  - followee フォローされる人
  - follow フォローのモデル
  - User followings ユーザーがフォローしている人たち
  - User followers ユーザーをフォローしている人たち

## 参考

### has_many through

> User has many comments, throught blogs

> 直訳：ユーザーは多くのコメントを持っている、ブログを通して

http://mikamisan.hatenablog.com/entry/2016/03/01/081345

### 一つ前のページに戻るボタンの実装

https://qiita.com/nekojoker/items/cb662de7cbb65e438985