### PR TITLE
GitHub Actionsで利用するRubyのインストールアクションを変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Ruby version specified in `.ruby-version`
-        uses: eregon/use-ruby-action@master
+        uses: ruby/setup-ruby
       - name: Install required apt packages & Install chrome
         run: |
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Ruby version specified in `.ruby-version`
-        uses: ruby/setup-ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: trueruby/setup-ruby
       - name: Install required apt packages & Install chrome
         run: |
           wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -


### PR DESCRIPTION
## 参考までに
ruby/setup-ruby はもともと eregon/use-ruby-action だったらしい

https://github.com/ruby/setup-ruby#history